### PR TITLE
fix: use next public env variable where necessary

### DIFF
--- a/src/firebaseconfig/index.ts
+++ b/src/firebaseconfig/index.ts
@@ -9,7 +9,7 @@ import { getFunctions } from "firebase/functions"
 // Your web app's Firebase configuration
 // For Firebase JS SDK v7.20.0 and later, measurementId is optional
 export const firebaseConfig =
-  process.env.VERCEL_ENV == "production"
+  process.env.NEXT_PUBLIC_VERCEL_ENV == "production"
     ? {
         apiKey: "AIzaSyAEONmJg_Kq-qBI0Z4wr9zbKY0eV9SU_ZE",
         authDomain: "qoat-app.firebaseapp.com",

--- a/src/pages/quiz/browse/index.tsx
+++ b/src/pages/quiz/browse/index.tsx
@@ -13,8 +13,10 @@ import SearchWidget from "components/Modules/Search/SearchWidget"
 import Hits from "components/Modules/Search/Hits"
 
 const searchClient = algoliasearch(
-  process.env.VERCEL_ENV == "production" ? "AB1F9YGSDE" : "X89JRCQYV8",
-  process.env.VERCEL_ENV == "production"
+  process.env.NEXT_PUBLIC_VERCEL_ENV == "production"
+    ? "AB1F9YGSDE"
+    : "X89JRCQYV8",
+  process.env.NEXT_PUBLIC_VERCEL_ENV == "production"
     ? "f5a646aaee44174d9b7c0b35f6888652"
     : "90f76fc7d4cbe92b5d2fd2b1257da5e6"
 )


### PR DESCRIPTION
This should be the last of a series of commits caused by me not knowing how vercel handles env variables beforehand